### PR TITLE
fix(merchant): bound amount/payTo/network before verify or settle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,3 +167,17 @@ FACILITATOR_SVM_NETWORK=solana
 # PRIVATE_KEY=0xYourMerchantKey
 # OPENAI_API_KEY=sk-xxx
 
+
+# -----------------------------------------------------------------------------
+# Payment bounds (optional — checked before verify/settle)
+# -----------------------------------------------------------------------------
+# Max payment amount in atomic units (USDC micro-units). Unset = no max.
+# Example: 100000 = $0.10 USDC
+# MAX_PAYMENT_AMOUNT=100000
+
+# Comma-separated allowed networks (legacy or CAIP-2). Unset = any configured network.
+# NETWORK_ALLOWLIST=base-sepolia,eip155:84532
+
+# When bounds are enabled, payload payTo must match PAY_TO_ADDRESS (default on).
+# Set false to disable payTo matching while keeping amount/network bounds.
+# ENFORCE_PAYTO_MATCH=true

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ npm-debug.log*
 
 # TypeScript
 *.tsbuildinfo
+node_modules/

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev": "tsc && node dist/server.js",
     "dev:facilitator": "tsc && node dist/facilitator.js",
     "test": "npm run build && node dist/testClient.js",
+    "test:unit": "tsc && node --test dist/payment-bounds.test.js dist/merchant-bounds-path.test.js",
     "test:solana": "npm run build && node dist/testClientSolana.js",
     "test:shell": "bash test-request.sh",
     "setup:solana": "npm run build && node dist/setupSolanaWallets.js",

--- a/src/MerchantExecutor.ts
+++ b/src/MerchantExecutor.ts
@@ -7,6 +7,11 @@ import type {
   PaymentRequirements,
   Network,
 } from '@x402/core/types';
+import {
+  evaluatePaymentBounds,
+  fieldsFromPaymentPayload,
+  type PaymentBoundsConfig,
+} from './payment-bounds.js';
 
 // NOTE: The default x402 facilitator only supports TESTNETS
 // For mainnet support, you need to run your own facilitator or use direct settlement (EVM only)
@@ -326,6 +331,15 @@ export interface MerchantExecutorOptions {
   assetName?: string;
   explorerUrl?: string;
   chainId?: number;
+  /**
+   * Optional payment bounds checked before verify/settle (facilitator or direct).
+   * When null/undefined, prior unbounded behavior is preserved.
+   */
+  paymentBounds?: PaymentBoundsConfig | null;
+  /** Convenience: max amount in atomic units (sets paymentBounds.maxPaymentAmount). */
+  maxPaymentAmount?: string | bigint;
+  /** Convenience: network allowlist (sets paymentBounds.networkAllowlist). */
+  networkAllowlist?: string[];
 }
 
 export interface VerifyResult {
@@ -355,6 +369,7 @@ export class MerchantExecutor {
   private readonly assetName: string;
   private readonly chainId?: number;
   private resourceServer?: x402ResourceServer;
+  private readonly paymentBounds: PaymentBoundsConfig | null;
 
   constructor(options: MerchantExecutorOptions) {
     // Convert legacy network name to CAIP-2 format if needed
@@ -389,6 +404,9 @@ export class MerchantExecutor {
     this.assetName = assetName;
     this.chainId = chainId;
     this.explorerUrl = explorerUrl;
+
+    // Optional bounds (env/options). Unset → no pre-verify/settle checks.
+    this.paymentBounds = this.resolvePaymentBounds(options);
 
     // Build x402 v2 payment requirements
     this.requirements = {
@@ -591,6 +609,16 @@ export class MerchantExecutor {
     console.log(`   To: ${this.requirements.payTo}`);
     console.log(`   Amount: ${this.requirements.amount}`);
 
+    // Bounds before facilitator/local verify — hot path, not a demo.
+    const boundFailure = this.checkPaymentBounds(payload);
+    if (boundFailure) {
+      console.log(`\n❌ Payment bounds rejected: ${boundFailure.reason}`);
+      return {
+        isValid: false,
+        invalidReason: boundFailure.reason,
+      };
+    }
+
     try {
       const result =
         this.mode === 'direct'
@@ -624,6 +652,17 @@ export class MerchantExecutor {
     console.log(`   Network: ${this.network}`);
     console.log(`   Amount: ${this.requirements.amount} (micro units)`);
     console.log(`   Pay to: ${this.requirements.payTo}`);
+
+    // Bounds before facilitator/local settle — same gate as verify.
+    const boundFailure = this.checkPaymentBounds(payload);
+    if (boundFailure) {
+      console.log(`\n❌ Payment bounds rejected: ${boundFailure.reason}`);
+      return {
+        success: false,
+        network: this.network,
+        errorReason: boundFailure.reason,
+      };
+    }
 
     try {
       const result =
@@ -855,6 +894,67 @@ export class MerchantExecutor {
   private getAtomicAmount(priceUsd: number): string {
     const atomicUnits = Math.floor(priceUsd * 1_000_000);
     return atomicUnits.toString();
+  }
+
+  private resolvePaymentBounds(
+    options: MerchantExecutorOptions
+  ): PaymentBoundsConfig | null {
+    if (options.paymentBounds === null) {
+      return null;
+    }
+    if (options.paymentBounds) {
+      return {
+        ...options.paymentBounds,
+        expectedPayTo:
+          options.paymentBounds.expectedPayTo ?? options.payToAddress,
+      };
+    }
+
+    const hasMax = options.maxPaymentAmount !== undefined;
+    const hasNet = (options.networkAllowlist?.length ?? 0) > 0;
+    if (!hasMax && !hasNet) {
+      return null;
+    }
+
+    let maxPaymentAmount: bigint | undefined;
+    if (options.maxPaymentAmount !== undefined) {
+      maxPaymentAmount =
+        typeof options.maxPaymentAmount === 'bigint'
+          ? options.maxPaymentAmount
+          : BigInt(String(options.maxPaymentAmount).trim());
+    }
+
+    return {
+      maxPaymentAmount,
+      networkAllowlist: hasNet ? options.networkAllowlist : undefined,
+      expectedPayTo: options.payToAddress,
+      enforcePayToMatch: true,
+    };
+  }
+
+  /**
+   * Run optional payment bounds before verify/settle (facilitator or direct).
+   * Returns a failure reason or null when allowed / bounds unset.
+   */
+  private checkPaymentBounds(
+    payload: PaymentPayload
+  ): { reason: string } | null {
+    if (!this.paymentBounds) {
+      return null;
+    }
+    const result = evaluatePaymentBounds(
+      this.paymentBounds,
+      {
+        amount: this.requirements.amount,
+        payTo: this.requirements.payTo,
+        network: String(this.requirements.network),
+      },
+      fieldsFromPaymentPayload(payload)
+    );
+    if (!result.ok) {
+      return { reason: result.reason };
+    }
+    return null;
   }
 
   private buildHeaders() {

--- a/src/merchant-bounds-path.test.ts
+++ b/src/merchant-bounds-path.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Drives the real MerchantExecutor verify/settle entry points with bounds set
+ * so the facilitator is never called — proves the hot-path gate runs first.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { MerchantExecutor } from './MerchantExecutor.js';
+import type { PaymentPayload } from '@x402/core/types';
+
+function minimalPayload(overrides?: {
+  payTo?: string;
+  network?: string;
+  amount?: string;
+}): PaymentPayload {
+  return {
+    x402Version: 2,
+    accepted: {
+      scheme: 'exact',
+      network: overrides?.network ?? 'eip155:84532',
+      asset: '0xasset',
+      payTo: overrides?.payTo ?? '0xAbC0000000000000000000000000000000000001',
+      amount: overrides?.amount ?? '100000',
+    },
+    payload: {
+      authorization: {
+        from: '0xpayer',
+        to: overrides?.payTo ?? '0xAbC0000000000000000000000000000000000001',
+        value: overrides?.amount ?? '100000',
+      },
+      signature: '0xsig',
+    },
+  } as unknown as PaymentPayload;
+}
+
+describe('MerchantExecutor payment bounds hot path', () => {
+  it('verifyPayment rejects over-max amount without calling facilitator', async () => {
+    // price 0.1 USD → 100000 atomic; max 50 → reject before network I/O
+    const merchant = new MerchantExecutor({
+      payToAddress: '0xAbC0000000000000000000000000000000000001',
+      network: 'base-sepolia',
+      price: 0.1,
+      paymentBounds: {
+        maxPaymentAmount: 50n,
+        expectedPayTo: '0xAbC0000000000000000000000000000000000001',
+        enforcePayToMatch: true,
+      },
+    });
+
+    const result = await merchant.verifyPayment(minimalPayload());
+    assert.equal(result.isValid, false);
+    assert.match(String(result.invalidReason), /MAX_PAYMENT_AMOUNT/);
+  });
+
+  it('settlePayment rejects over-max amount without calling facilitator', async () => {
+    const merchant = new MerchantExecutor({
+      payToAddress: '0xAbC0000000000000000000000000000000000001',
+      network: 'base-sepolia',
+      price: 0.1,
+      paymentBounds: { maxPaymentAmount: 50n },
+    });
+
+    const result = await merchant.settlePayment(minimalPayload());
+    assert.equal(result.success, false);
+    assert.match(String(result.errorReason), /MAX_PAYMENT_AMOUNT/);
+  });
+
+  it('verifyPayment rejects network not on allowlist', async () => {
+    const merchant = new MerchantExecutor({
+      payToAddress: '0xAbC0000000000000000000000000000000000001',
+      network: 'base-sepolia',
+      price: 0.1,
+      paymentBounds: {
+        networkAllowlist: ['eip155:1'],
+      },
+    });
+
+    const result = await merchant.verifyPayment(minimalPayload());
+    assert.equal(result.isValid, false);
+    assert.match(String(result.invalidReason), /NETWORK_ALLOWLIST/);
+  });
+
+  it('verifyPayment rejects payTo mismatch when enforce enabled', async () => {
+    const merchant = new MerchantExecutor({
+      payToAddress: '0xAbC0000000000000000000000000000000000001',
+      network: 'base-sepolia',
+      price: 0.1,
+      paymentBounds: {
+        maxPaymentAmount: 1_000_000n,
+        expectedPayTo: '0xAbC0000000000000000000000000000000000001',
+        enforcePayToMatch: true,
+      },
+    });
+
+    const result = await merchant.verifyPayment(
+      minimalPayload({ payTo: '0xdead000000000000000000000000000000000000' })
+    );
+    assert.equal(result.isValid, false);
+    assert.match(String(result.invalidReason), /payTo/);
+  });
+
+  it('leaves prior path open when paymentBounds unset (no early bounds reject)', async () => {
+    // Without bounds, verify will attempt facilitator and fail network — not a bounds reason.
+    const merchant = new MerchantExecutor({
+      payToAddress: '0xAbC0000000000000000000000000000000000001',
+      network: 'base-sepolia',
+      price: 0.1,
+      facilitatorUrl: 'http://127.0.0.1:9', // closed port → fast fail
+    });
+
+    const result = await merchant.verifyPayment(minimalPayload());
+    assert.equal(result.isValid, false);
+    // Must NOT be a MAX_PAYMENT_AMOUNT / bounds message
+    assert.doesNotMatch(String(result.invalidReason ?? ''), /MAX_PAYMENT_AMOUNT|NETWORK_ALLOWLIST|payTo does not match/);
+  });
+});

--- a/src/payment-bounds.test.ts
+++ b/src/payment-bounds.test.ts
@@ -1,0 +1,129 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  evaluatePaymentBounds,
+  fieldsFromPaymentPayload,
+  normalizePayTo,
+  parsePaymentBoundsFromEnv,
+} from './payment-bounds.js';
+
+describe('normalizePayTo', () => {
+  it('lowercases EVM addresses', () => {
+    assert.equal(normalizePayTo('0xAbC'), '0xabc');
+  });
+
+  it('leaves non-0x addresses unchanged', () => {
+    assert.equal(normalizePayTo('SoLanaAddr'), 'SoLanaAddr');
+  });
+});
+
+describe('parsePaymentBoundsFromEnv', () => {
+  it('returns null when no bound knobs are set', () => {
+    assert.equal(parsePaymentBoundsFromEnv({ PAY_TO_ADDRESS: '0xabc' }), null);
+  });
+
+  it('parses MAX_PAYMENT_AMOUNT and NETWORK_ALLOWLIST', () => {
+    const cfg = parsePaymentBoundsFromEnv({
+      MAX_PAYMENT_AMOUNT: '100000',
+      NETWORK_ALLOWLIST: 'eip155:84532, solana-devnet',
+      PAY_TO_ADDRESS: '0xAbC',
+    });
+    assert.ok(cfg);
+    assert.equal(cfg!.maxPaymentAmount, 100000n);
+    assert.deepEqual(cfg!.networkAllowlist, ['eip155:84532', 'solana-devnet']);
+    assert.equal(cfg!.expectedPayTo, '0xAbC');
+  });
+
+  it('throws on non-integer MAX_PAYMENT_AMOUNT', () => {
+    assert.throws(
+      () => parsePaymentBoundsFromEnv({ MAX_PAYMENT_AMOUNT: '1.5' }),
+      /MAX_PAYMENT_AMOUNT/
+    );
+  });
+
+  it('enables payTo-only mode when ENFORCE_PAYTO_MATCH=true', () => {
+    const cfg = parsePaymentBoundsFromEnv({
+      ENFORCE_PAYTO_MATCH: 'true',
+      PAY_TO_ADDRESS: '0xabc',
+    });
+    assert.ok(cfg);
+    assert.equal(cfg!.enforcePayToMatch, true);
+    assert.equal(cfg!.expectedPayTo, '0xabc');
+  });
+});
+
+describe('evaluatePaymentBounds', () => {
+  const merchant = {
+    amount: '100000',
+    payTo: '0xAbC',
+    network: 'eip155:84532',
+  };
+
+  it('allows when under max and on allowlist', () => {
+    const result = evaluatePaymentBounds(
+      {
+        maxPaymentAmount: 200000n,
+        networkAllowlist: ['eip155:84532'],
+        expectedPayTo: '0xabc',
+        enforcePayToMatch: true,
+      },
+      merchant,
+      { payTo: '0xABC' }
+    );
+    assert.equal(result.ok, true);
+  });
+
+  it('rejects amount above max before facilitator would be called', () => {
+    const result = evaluatePaymentBounds(
+      { maxPaymentAmount: 50n },
+      merchant
+    );
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.reason, /exceeds MAX_PAYMENT_AMOUNT/);
+    }
+  });
+
+  it('rejects network not on allowlist', () => {
+    const result = evaluatePaymentBounds(
+      { networkAllowlist: ['eip155:1'] },
+      merchant
+    );
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.reason, /NETWORK_ALLOWLIST/);
+    }
+  });
+
+  it('rejects payload payTo mismatch when enforce enabled', () => {
+    const result = evaluatePaymentBounds(
+      {
+        maxPaymentAmount: 1_000_000n,
+        expectedPayTo: '0xabc',
+        enforcePayToMatch: true,
+      },
+      merchant,
+      { payTo: '0xdead' }
+    );
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.reason, /payTo/);
+    }
+  });
+
+  it('does not apply max when config has no max', () => {
+    const result = evaluatePaymentBounds({}, { amount: '999999999999' });
+    assert.equal(result.ok, true);
+  });
+});
+
+describe('fieldsFromPaymentPayload', () => {
+  it('reads accepted and authorization fallbacks', () => {
+    const fields = fieldsFromPaymentPayload({
+      accepted: { payTo: '0x1', network: 'eip155:8453', amount: '10' },
+    });
+    assert.equal(fields.payTo, '0x1');
+    assert.equal(fields.network, 'eip155:8453');
+    assert.equal(fields.amount, '10');
+  });
+});

--- a/src/payment-bounds.ts
+++ b/src/payment-bounds.ts
@@ -1,0 +1,184 @@
+/**
+ * Env-gated payment bounds checked before facilitator verify/settle.
+ * Unset config → no bounds (prior behavior). No third-party brand deps.
+ */
+
+export type PaymentBoundsConfig = {
+  /** Max amount in atomic units (e.g. USDC micro-units). */
+  maxPaymentAmount?: bigint;
+  /** If non-empty, network must be listed (exact match after trim). */
+  networkAllowlist?: string[];
+  /**
+   * Expected merchant payTo. When enforcePayToMatch is true and payload
+   * includes payTo, it must match (EVM addresses compared case-insensitively).
+   */
+  expectedPayTo?: string;
+  /** When true, reject payload payTo mismatch vs expectedPayTo/merchant. */
+  enforcePayToMatch?: boolean;
+};
+
+export type PaymentBoundFields = {
+  amount?: string;
+  payTo?: string;
+  network?: string;
+};
+
+export type PaymentBoundsFailure = {
+  ok: false;
+  reason: string;
+};
+
+export type PaymentBoundsSuccess = { ok: true };
+
+export type PaymentBoundsResult = PaymentBoundsSuccess | PaymentBoundsFailure;
+
+function splitCsv(raw: string | undefined): string[] {
+  if (!raw?.trim()) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseAtomicAmount(raw: string | undefined): bigint | undefined {
+  if (raw === undefined || raw === '') return undefined;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return undefined;
+  try {
+    return BigInt(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Normalize EVM 0x addresses for comparison; leave other formats as-is. */
+export function normalizePayTo(payTo: string): string {
+  if (payTo.startsWith('0x') || payTo.startsWith('0X')) {
+    return payTo.toLowerCase();
+  }
+  return payTo;
+}
+
+/**
+ * Parse bounds from process env.
+ * Returns null when no bound knobs are set — PAY_TO_ADDRESS alone does not
+ * enable bounds (server always requires it; prior verify/settle path preserved).
+ */
+export function parsePaymentBoundsFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  defaults?: { expectedPayTo?: string }
+): PaymentBoundsConfig | null {
+  const maxRaw = env.MAX_PAYMENT_AMOUNT?.trim();
+  let maxPaymentAmount: bigint | undefined;
+  if (maxRaw) {
+    maxPaymentAmount = parseAtomicAmount(maxRaw);
+    if (maxPaymentAmount === undefined) {
+      throw new Error(
+        `MAX_PAYMENT_AMOUNT must be a non-negative integer (atomic units), got: ${maxRaw}`
+      );
+    }
+  }
+
+  const networkAllowlist = splitCsv(env.NETWORK_ALLOWLIST);
+  const expectedPayTo =
+    env.PAY_TO_ADDRESS?.trim() || defaults?.expectedPayTo?.trim() || undefined;
+
+  const enforceExplicitTrue = env.ENFORCE_PAYTO_MATCH === 'true';
+  const enforceExplicitFalse = env.ENFORCE_PAYTO_MATCH === 'false';
+
+  const hasMax = maxPaymentAmount !== undefined;
+  const hasNet = networkAllowlist.length > 0;
+
+  if (!hasMax && !hasNet && !enforceExplicitTrue) {
+    return null;
+  }
+
+  return {
+    maxPaymentAmount,
+    networkAllowlist: hasNet ? networkAllowlist : undefined,
+    expectedPayTo,
+    enforcePayToMatch: enforceExplicitFalse
+      ? false
+      : enforceExplicitTrue || hasMax || hasNet,
+  };
+}
+
+/**
+ * Evaluate amount / network / payTo bounds against merchant + optional payload fields.
+ * Prefer merchant requirements for amount/network; use payload payTo when present.
+ */
+export function evaluatePaymentBounds(
+  config: PaymentBoundsConfig,
+  merchant: PaymentBoundFields,
+  payload?: PaymentBoundFields
+): PaymentBoundsResult {
+  const amount = merchant.amount ?? payload?.amount;
+  const network = merchant.network ?? payload?.network;
+  const payloadPayTo = payload?.payTo;
+  const merchantPayTo = merchant.payTo ?? config.expectedPayTo;
+
+  if (config.maxPaymentAmount !== undefined) {
+    if (!amount) {
+      return {
+        ok: false,
+        reason: 'payment amount missing while MAX_PAYMENT_AMOUNT is set',
+      };
+    }
+    const amt = parseAtomicAmount(amount);
+    if (amt === undefined) {
+      return {
+        ok: false,
+        reason: `payment amount is not a valid integer atomic unit: ${amount}`,
+      };
+    }
+    if (amt > config.maxPaymentAmount) {
+      return {
+        ok: false,
+        reason: `amount ${amount} exceeds MAX_PAYMENT_AMOUNT (${config.maxPaymentAmount.toString()})`,
+      };
+    }
+  }
+
+  if (config.networkAllowlist?.length) {
+    if (!network) {
+      return {
+        ok: false,
+        reason: 'network missing while NETWORK_ALLOWLIST is set',
+      };
+    }
+    if (!config.networkAllowlist.includes(network)) {
+      return {
+        ok: false,
+        reason: `network "${network}" not in NETWORK_ALLOWLIST`,
+      };
+    }
+  }
+
+  if (config.enforcePayToMatch && payloadPayTo) {
+    const expected = config.expectedPayTo ?? merchantPayTo;
+    if (expected) {
+      if (normalizePayTo(payloadPayTo) !== normalizePayTo(expected)) {
+        return {
+          ok: false,
+          reason: 'payload payTo does not match merchant PAY_TO_ADDRESS',
+        };
+      }
+    }
+  }
+
+  return { ok: true };
+}
+
+/** Extract common bound fields from an x402 payment payload (best-effort). */
+export function fieldsFromPaymentPayload(payload: unknown): PaymentBoundFields {
+  const p = payload as {
+    accepted?: { payTo?: string; network?: string; amount?: string };
+    payload?: { authorization?: { to?: string; value?: string } };
+  };
+  return {
+    payTo: p?.accepted?.payTo ?? p?.payload?.authorization?.to ?? undefined,
+    network: p?.accepted?.network,
+    amount:
+      p?.accepted?.amount ?? p?.payload?.authorization?.value ?? undefined,
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import dotenv from 'dotenv';
 
 import { ExampleService } from './ExampleService.js';
 import { MerchantExecutor, type MerchantExecutorOptions } from './MerchantExecutor.js';
+import { parsePaymentBoundsFromEnv } from './payment-bounds.js';
 import type { PaymentPayload } from '@x402/core/types';
 import {
   EventQueue,
@@ -156,6 +157,12 @@ const exampleService = new ExampleService({
   seed: AI_PROVIDER === 'eigenai' ? AI_SEED : undefined,
 });
 
+// Optional payment bounds (MAX_PAYMENT_AMOUNT / NETWORK_ALLOWLIST / ENFORCE_PAYTO_MATCH).
+// Unset → prior unbounded verify/settle behavior.
+const paymentBounds = parsePaymentBoundsFromEnv(process.env, {
+  expectedPayTo: PAY_TO_ADDRESS,
+});
+
 // Initialize the example service (replace with your own service)
 const merchantOptions: MerchantExecutorOptions = {
   payToAddress: PAY_TO_ADDRESS,
@@ -171,6 +178,7 @@ const merchantOptions: MerchantExecutorOptions = {
   assetName: ASSET_NAME,
   explorerUrl: EXPLORER_URL,
   chainId: CHAIN_ID,
+  paymentBounds,
 };
 
 const merchantExecutor = new MerchantExecutor(merchantOptions);
@@ -198,6 +206,21 @@ if (settlementMode === 'direct') {
 
 console.log('🚀 x402 v2 Payment API initialized');
 console.log(`💰 Payment address: ${PAY_TO_ADDRESS}`);
+if (paymentBounds) {
+  const parts: string[] = [];
+  if (paymentBounds.maxPaymentAmount !== undefined) {
+    parts.push(`maxAmount=${paymentBounds.maxPaymentAmount.toString()}`);
+  }
+  if (paymentBounds.networkAllowlist?.length) {
+    parts.push(`networks=${paymentBounds.networkAllowlist.length}`);
+  }
+  if (paymentBounds.enforcePayToMatch) {
+    parts.push('payToMatch=on');
+  }
+  console.log(`🛡️  Payment bounds: enabled (${parts.join(', ')})`);
+} else {
+  console.log('🛡️  Payment bounds: off (set MAX_PAYMENT_AMOUNT / NETWORK_ALLOWLIST to enable)');
+}
 console.log(`🌐 Network: ${NETWORK}`);
 console.log(`💵 Price per request: $0.10 USDC`);
 


### PR DESCRIPTION
## Summary

Adds **optional, env-gated payment bounds** in `MerchantExecutor` so verify/settle never reach the facilitator (or direct settlement) with unbounded amount, wrong network, or mismatched payTo.

| Env | Effect |
|-----|--------|
| `MAX_PAYMENT_AMOUNT` | Max amount in **atomic units** (USDC micro-units); reject if merchant amount exceeds |
| `NETWORK_ALLOWLIST` | Comma-separated networks (legacy or CAIP-2); reject if not listed |
| `ENFORCE_PAYTO_MATCH` | With bounds enabled (or set `true` alone), payload payTo must match `PAY_TO_ADDRESS` |
| (unset all) | **No behavior change** — prior unbounded path preserved |

## Hot path

Checks run at the start of `verifyPayment` / `settlePayment` **before** `callFacilitator` or local settle.

## Files

- `src/payment-bounds.ts` — pure evaluate/parse helpers
- `src/MerchantExecutor.ts` — wire bounds gate
- `src/server.ts` — `parsePaymentBoundsFromEnv` into merchant options
- `.env.example` — documented knobs
- Unit tests: `npm run test:unit` (17 pass)

## Why

Starter kits are the default agent/human copy path. Unbounded settle is a real footgun. Operators keep defaults; opt into bounds via env.

## Verify

```bash
npm install
npm run test:unit
# with MAX_PAYMENT_AMOUNT below quote → verify/settle rejected before facilitator
```

## Notes

No third-party product dependency. Brand-agnostic operator knobs only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/x402-starter-kit/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->