### PR TITLE
docs: add ArisPay as a Base mainnet FACILITATOR_URL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,20 @@ FACILITATOR_URL=https://your-mainnet-facilitator.example.com npm run start
 
 **Some Available Facilitators (No API key required):**
 
+- [ArisPay](https://facilitator.arispay.app) - Base mainnet, USDC and EURC, no signup
 - [PayAI](https://facilitator.payai.network)
 - [x402rs](https://facilitator.x402.rs)
 - [Heurist](https://facilitator.heurist.xyz)
 - [Corbits](https://facilitator.corbits.dev)
+
+For a no-signup Base mainnet server using ArisPay:
+
+```bash
+NETWORK=base FACILITATOR_URL=https://facilitator.arispay.app npm run start
+```
+
+This selects ArisPay explicitly; it does not change the starter's testnet
+default or require an ArisPay account or API key.
 
 #### Option 3: Direct Settlement (EVM Only)
 


### PR DESCRIPTION
Documents ArisPay as one no-signup Base mainnet FACILITATOR_URL option. The x402.org testnet default and all generated application behavior remain unchanged. Verifiable in-band at https://facilitator.arispay.app/supported.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/x402-starter-kit/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->